### PR TITLE
Increase process priority

### DIFF
--- a/scroll_remap.ahk
+++ b/scroll_remap.ahk
@@ -1,5 +1,11 @@
 #Requires AutoHotkey v2.0
 
+; Increase the process priority to see if that stops
+; the script from sporadically holding and sending
+; XButton1/XButton2 inputs when it shouldn't
+ProcessSetPriority "AboveNormal"
+
+; Set the tray icon
 TraySetIcon "mouse.ico"
 
 ; Deactivate "too many hotkeys too fast" warning because deactivating the


### PR DESCRIPTION
Increase process priority to "AboveNormal" to hopefully fix issue where scroll is held and mouse side button inputs are sent when they should be deactivated.